### PR TITLE
Set Up Main Layout with Sidebar and Router Outlet

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,3 +1,2 @@
 
-ok i will 
 <router-outlet />

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,3 +1,21 @@
 import { Routes } from '@angular/router';
+import { LayoutComponent } from '@components/layout/layout.component';
+import { InvoicesComponent } from '@pages/invoices/invoices.component';
 
-export const routes: Routes = [];
+export const routes: Routes = [
+  {
+    path: '',
+    component: LayoutComponent,
+    children: [
+      {
+        path: '',
+        redirectTo: 'invoices',
+        pathMatch: 'full',
+      },
+      {
+        path: 'invoices',
+        component: InvoicesComponent,
+      },
+    ],
+  },
+];

--- a/src/app/components/icon/icon.component.css
+++ b/src/app/components/icon/icon.component.css
@@ -1,0 +1,7 @@
+.sidebar__theme-icon {
+  margin-inline: auto;
+}
+
+.sidebar__theme-avatar {
+  border-radius: 100%;
+}

--- a/src/app/components/icon/icon.component.html
+++ b/src/app/components/icon/icon.component.html
@@ -1,1 +1,8 @@
-<p>icon works!</p>
+<img
+  [ngSrc]="iconData.src"
+  [alt]="iconData.alt ?? ''"
+  [width]="iconData.width"
+  [height]="iconData.height"
+  [class]="iconData.className ?? ''"
+  priority
+/>

--- a/src/app/components/icon/icon.component.ts
+++ b/src/app/components/icon/icon.component.ts
@@ -1,12 +1,15 @@
-import { Component } from '@angular/core';
+import { Component, Input } from '@angular/core';
+import { NgOptimizedImage } from '@angular/common';
+import { IconData } from '@interfaces/index';
 
 @Component({
   selector: 'app-icon',
   standalone: true,
-  imports: [],
+  imports: [NgOptimizedImage],
   templateUrl: './icon.component.html',
-  styleUrl: './icon.component.css'
+  styleUrl: './icon.component.css',
 })
+  
 export class IconComponent {
-
+  @Input({ required: true }) iconData!: IconData;
 }

--- a/src/app/components/layout/layout.component.css
+++ b/src/app/components/layout/layout.component.css
@@ -1,0 +1,5 @@
+main {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  min-height: 100dvh;
+}

--- a/src/app/components/layout/layout.component.html
+++ b/src/app/components/layout/layout.component.html
@@ -1,0 +1,6 @@
+<main>
+  <app-side-nav />
+  <div>
+    <router-outlet></router-outlet>
+  </div>
+</main>

--- a/src/app/components/layout/layout.component.spec.ts
+++ b/src/app/components/layout/layout.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { LayoutComponent } from './layout.component';
+
+describe('LayoutComponent', () => {
+  let component: LayoutComponent;
+  let fixture: ComponentFixture<LayoutComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [LayoutComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(LayoutComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/layout/layout.component.ts
+++ b/src/app/components/layout/layout.component.ts
@@ -1,0 +1,15 @@
+import { Component } from '@angular/core';
+import { SideNavComponent } from './side-nav/side-nav.component';
+import { RouterOutlet } from '@angular/router';
+
+@Component({
+  selector: 'app-layout',
+  standalone: true,
+  imports: [SideNavComponent, RouterOutlet],
+  templateUrl: './layout.component.html',
+  styleUrl: './layout.component.css',
+})
+export class LayoutComponent {
+
+  
+}

--- a/src/app/components/layout/side-nav/side-nav.component.css
+++ b/src/app/components/layout/side-nav/side-nav.component.css
@@ -1,0 +1,25 @@
+.sidebar {
+  background-color: var(--color-steel-gray);
+  min-height: 100%;
+  border-top-right-radius: 2rem;
+  border-bottom-right-radius: 2rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.sidebar__theme {
+  display: flex;
+  flex-direction: column;
+  gap: 3.2rem;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 2rem;
+}
+
+.sidebar__theme-icon-container {
+  width: 100%;
+  border-bottom: 2px solid var(--color-border-gray);
+  padding-bottom: 3rem;
+}
+

--- a/src/app/components/layout/side-nav/side-nav.component.html
+++ b/src/app/components/layout/side-nav/side-nav.component.html
@@ -1,0 +1,11 @@
+<aside class="sidebar">
+  <div class="sidebar__logo">
+    <app-icon [iconData]="iconData.logo" />
+  </div>
+  <div class="sidebar__theme">
+    <div class="sidebar__theme-icon-container">
+      <app-icon [iconData]="iconData.moon" />
+    </div>
+    <app-icon [iconData]="iconData.avatar" />
+  </div>
+</aside>

--- a/src/app/components/layout/side-nav/side-nav.component.spec.ts
+++ b/src/app/components/layout/side-nav/side-nav.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SideNavComponent } from './side-nav.component';
+
+describe('SideNavComponent', () => {
+  let component: SideNavComponent;
+  let fixture: ComponentFixture<SideNavComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SideNavComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(SideNavComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/layout/side-nav/side-nav.component.ts
+++ b/src/app/components/layout/side-nav/side-nav.component.ts
@@ -1,0 +1,15 @@
+import { Component } from '@angular/core';
+import { NgOptimizedImage } from '@angular/common';
+import { ICONS } from '@constants/index';
+import { IconComponent } from '@components/icon/icon.component';
+
+@Component({
+  selector: 'app-side-nav',
+  standalone: true,
+  imports: [NgOptimizedImage, IconComponent],
+  templateUrl: './side-nav.component.html',
+  styleUrl: './side-nav.component.css',
+})
+export class SideNavComponent {
+  readonly iconData = ICONS;
+}

--- a/src/app/pages/invoices/invoices.component.html
+++ b/src/app/pages/invoices/invoices.component.html
@@ -1,0 +1,1 @@
+<p>invoices works!</p>

--- a/src/app/pages/invoices/invoices.component.spec.ts
+++ b/src/app/pages/invoices/invoices.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { InvoicesComponent } from './invoices.component';
+
+describe('InvoicesComponent', () => {
+  let component: InvoicesComponent;
+  let fixture: ComponentFixture<InvoicesComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [InvoicesComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(InvoicesComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/pages/invoices/invoices.component.ts
+++ b/src/app/pages/invoices/invoices.component.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-invoices',
+  standalone: true,
+  imports: [],
+  templateUrl: './invoices.component.html',
+  styleUrl: './invoices.component.css'
+})
+export class InvoicesComponent {
+
+}

--- a/src/assets/logo.svg
+++ b/src/assets/logo.svg
@@ -1,1 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="28" height="26"><path fill="#FFF" fill-rule="evenodd" d="M20.513 0C24.965 2.309 28 6.91 28 12.21 28 19.826 21.732 26 14 26S0 19.826 0 12.21C0 6.91 3.035 2.309 7.487 0L14 12.9z"/></svg>
+<svg width="103" height="103" viewBox="0 0 103 103" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0 0H83C94.0457 0 103 8.9543 103 20V83C103 94.0457 94.0457 103 83 103H0V0Z" fill="#7C5DFA"/>
+<mask id="mask0_0_8959" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="0" y="0" width="103" height="103">
+<path d="M0 0H83C94.0457 0 103 8.9543 103 20V83C103 94.0457 94.0457 103 83 103H0V0Z" fill="white"/>
+</mask>
+<g mask="url(#mask0_0_8959)">
+<path d="M103 52H20C8.95431 52 0 60.9543 0 72V135C0 146.046 8.95431 155 20 155H103V52Z" fill="#9277FF"/>
+</g>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M42.6942 33.2923L52 52L61.3058 33.2923C67.6645 36.6408 72 43.3141 72 51C72 62.0457 63.0457 71 52 71C40.9543 71 32 62.0457 32 51C32 43.3141 36.3355 36.6408 42.6942 33.2923Z" fill="white"/>
+</svg>

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,0 +1,23 @@
+export const ICONS = {
+  moon: {
+    src: 'assets/icon-moon.svg',
+    alt: 'Moon Icon',
+    width: 20,
+    height: 20,
+    className: 'sidebar__theme-icon',
+  },
+  avatar: {
+    src: 'assets/image-avatar.jpg',
+    alt: 'User Avatar',
+    width: 40,
+    height: 40,
+    className: 'sidebar__theme-avatar',
+  },
+  logo: {
+    src: 'assets/logo.svg',
+    alt: 'App Logo',
+    width: 103,
+    height: 103,
+    className: 'sidebar__logo-image',
+  },
+};

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -1,0 +1,7 @@
+export interface IconData {
+  src: string;
+  alt?: string;
+  width?: number;
+  height?: number;
+  className?: string;
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -84,4 +84,11 @@ h6 {
 
   --color-error: #ec5757;
   --color-error-light: #ff9797;
+
+  --breakpoint-xs: 480px;
+  --breakpoint-sm: 768px;
+  --breakpoint-md: 992px;
+  --breakpoint-lg: 1200px;
+  --breakpoint-xl: 1440px;
+  --breakpoint-xxl: 1920px;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -68,27 +68,44 @@ h6 {
 }
 
 :root {
-  --color-primary: #7c5dfa;
-  --color-primary-light: #9277ff;
-
-  --color-secondary: #1e2139;
-  --color-secondary-dark: #252945;
-
-  --color-grey: #dfe3fa;
-  --color-grey-medium: #888eb0;
-  --color-grey-dark: #7e88c3;
-
-  --color-bg-base: #0c0e16;
-  --color-bg-light: #f8f8fb;
-  --color-bg-dark: #141625;
+  --color-primary-blue: #7c5dfa;
+  --color-secondary-blue: #9277ff;
+  --color-primary-red: #ec5757;
+  --color-secondary-red: #ff9797;
+  --color-amber: #ff8f00;
+  --color-mint-green: #33d69f;
+  --color-dark-gray: #1e2139;
+  --color-border-gray: #494e6e;
+  --color-deep-gray: #252945;
+  --color-light-gray: #dfe3fa;
+  --color-muted-blue: #888eb0;
+  --color-soft-blue: #7e88c3;
+  --color-very-dark: #0c0e16;
+  --color-steel-gray: #373b53;
+  --color-almost-white: #f8f8fb;
+  --color-midnight-gray: #141625;
+  --color-white: #ffffff;
 
   --color-error: #ec5757;
   --color-error-light: #ff9797;
 
-  --breakpoint-xs: 480px;
-  --breakpoint-sm: 768px;
-  --breakpoint-md: 992px;
-  --breakpoint-lg: 1200px;
-  --breakpoint-xl: 1440px;
-  --breakpoint-xxl: 1920px;
+  --breakpoint-tablet: 768px;
+  --breakpoint-small-desktop: 992px;
+  --breakpoint-desktop: 1200px;
+  --breakpoint-large-desktop: 1440px;
+}
+
+[data-theme="light"] {
+  --background-color: var(--color-almost-white);
+  --text-color: var(--color-very-dark);
+}
+
+[data-theme="dark"] {
+  --background-color: var(--color-midnight-gray);
+  --text-color: var(--color-white);
+}
+
+body {
+  background-color: var(--color-almost-white);
+  min-height: 100dvh;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,8 @@
     "paths": {
       "@app/*": ["app/*"],
       "@assets/*": ["assets/*"],
+      "@interfaces/*": ["interfaces/*"],
+      "@constants/*": ["constants/*"],
       "@environments/*": ["environments/*"],
       "@services/*": ["app/services/*"],
       "@components/*": ["app/components/*"],


### PR DESCRIPTION
This PR introduces the initial setup for the application's main layout, which includes:

1. **Sidebar Navigation Component (app-side-nav):** A reusable sidebar component for navigating between sections of the app.
2. **Router Outlet:** A placeholder for rendering the routed components within the layout.

![InvoiceApp-12-28-2024_01_02_PM](https://github.com/user-attachments/assets/66721908-8384-4d25-9f2d-95cefefc207d)
